### PR TITLE
Fix non-threadsafe kramdown loading warning

### DIFF
--- a/lib/haml/filters/kramdown.rb
+++ b/lib/haml/filters/kramdown.rb
@@ -1,1 +1,3 @@
+require 'kramdown'
+
 Haml::Filters.register_tilt_filter 'Kramdown', template_class: Tilt::KramdownTemplate


### PR DESCRIPTION
Fixes `WARN: tilt autoloading 'kramdown' in a non thread-safe way; explicit require 'kramdown' suggested.`