### PR TITLE
remove dependency on haml v4

### DIFF
--- a/haml-kramdown.gemspec
+++ b/haml-kramdown.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest'
 
-  spec.add_runtime_dependency 'haml', '~> 4.0'
+  spec.add_runtime_dependency 'haml'
   spec.add_runtime_dependency 'kramdown'
 end


### PR DESCRIPTION
(do we really need to limit this to haml 4? that was updated two years ago)